### PR TITLE
Revert "Wifi: Introduce a config parameter for IpReachabilityMonitor"

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -442,9 +442,6 @@
     <!-- Boolean indicating whether or not wifi firmware debugging is enabled -->
     <bool translatable="false" name="config_wifi_enable_wifi_firmware_debugging">true</bool>
 
-    <!-- IpReachability monitor enable/Disable -->
-    <bool translatable="false" name="config_wifi_ipreachability_monitor">false</bool>
-
     <!-- Integer size limit, in KB, for a single WifiLogger ringbuffer -->
     <integer translatable="false" name="config_wifi_logger_ring_buffer_size_limit_kb">32</integer>
 

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -297,7 +297,6 @@
   <java-symbol type="bool" name="config_wifi_enable_disconnection_debounce" />
   <java-symbol type="bool" name="config_wifi_revert_country_code_on_cellular_loss" />
   <java-symbol type="bool" name="config_wifi_enable_wifi_firmware_debugging" />
-  <java-symbol type="bool" name="config_wifi_ipreachability_monitor" />
   <java-symbol type="integer" name="config_wifi_logger_ring_buffer_size_limit_kb" />
   <java-symbol type="integer" name="config_wifi_logger_ring_buffer_default_size_limit_kb" />
   <java-symbol type="integer" name="config_wifi_logger_ring_buffer_verbose_size_limit_kb" />


### PR DESCRIPTION
This config is no longer needed, the code depending on it was removed.

This reverts commit 2c224e31989ff15c3e9f4708905da44c4c5e2b94.

Change-Id: I8eba6529a8f9f09f0442e106a696608bd1a37ae2